### PR TITLE
docs: add zed editor mcp configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,21 @@ Add to your editor's MCP config file:
 }
 ```
 
+Or with `uvx` (faster, no venv needed):
+
+```json
+{
+  "context_servers": {
+    "omega-memory": {
+      "command": {
+        "path": "uvx",
+        "args": ["omega-memory"]
+      }
+    }
+  }
+}
+```
+
 Open Zed settings: `Zed > Settings > Open Settings` (or edit `~/.config/zed/settings.json`)
 
 **Config file locations by editor:**


### PR DESCRIPTION
zed now supports mcp servers natively but uses context_servers instead of mcpServers. added the zed-specific config example to the readme.

included both python3 and uvx examples since uvx is faster and doesn't need a venv.

let me know if i should add anything else!