### PR TITLE
fix(sqlite_store): import_from_file race + concurrent-store SIGSEGV (#58)

### DIFF
--- a/src/omega/bridge.py
+++ b/src/omega/bridge.py
@@ -837,10 +837,18 @@ def _auto_relate(store, node_id: str, max_related: int = 3, min_similarity: floa
 def _schedule_auto_relate(store, node_id: str) -> None:
     """Fire _auto_relate in a background daemon thread (non-blocking).
 
+    Set ``OMEGA_AUTO_RELATE=0`` (also ``false``/``off``) to skip enrichment
+    entirely — parity with ``OMEGA_ENTITY_EXTRACTION``. Requested by issue #58
+    reporter as a safety valve for environments where auto-relate's thread
+    behavior is undesirable.
+
     Registers the thread on the store so close() can join it before tearing
     down the sqlite connection (prevents use-after-close segfaults in
     sqlite-vec native code during test teardown).
     """
+    if os.environ.get("OMEGA_AUTO_RELATE", "").lower() in ("0", "false", "off"):
+        return
+
     t_ref: list[threading.Thread] = []
 
     def _run():

--- a/src/omega/sqlite_store/_maintenance.py
+++ b/src/omega/sqlite_store/_maintenance.py
@@ -1,5 +1,6 @@
 """Maintenance, health, graph, entity, and I/O mixin for SQLiteStore."""
 
+import gc
 import logging
 import os
 import time as _time
@@ -1302,55 +1303,54 @@ class MaintenanceMixin:
         data = json.loads(raw_content)
         nodes = data.get("nodes", [])
 
-        if clear_existing:
-            # Atomic clear via executescript. WAL mode + isolation_level
-            # ="IMMEDIATE" on the connection (see _base.py:_connect) give
-            # readers a consistent pre-clear snapshot until the COMMIT
-            # inside the script — the original "BEGIN EXCLUSIVE" intent
-            # is satisfied without taking an exclusive lock.
-            #
-            # Why executescript instead of per-statement execute(): older
-            # SQLite libraries (Ubuntu CI ships 3.40-class, local dev
-            # tends to be 3.52+) are stricter about "SQL statements in
-            # progress" at commit time. Per-execute() returns a Cursor
-            # whose prepared statement may stay in PROGRESS until
-            # garbage collection, and the commit then fails with:
-            #
-            #   sqlite3.OperationalError: cannot commit transaction -
-            #     SQL statements in progress
-            #
-            # (omega-public CI failures 2026-05-19 through 2026-06-09.)
-            # executescript batches through SQLite's sqlite3_exec, which
-            # finalizes each prepared statement before the next runs, so
-            # the BEGIN/COMMIT pair inside the script lands atomically
-            # across every supported SQLite version.
-            script = ["BEGIN;", "DELETE FROM memories;"]
-            if self._vec_available:
-                script.append("DELETE FROM memories_vec;")
-            script.extend(["DELETE FROM edges;", "COMMIT;"])
-            try:
-                self._conn.executescript(" ".join(script))
-            except Exception as e:
-                logger.debug("Import clear failed, rolling back: %s", e)
+        # Serialize against the deferred-startup thread (PRAGMA integrity_check
+        # + WAL checkpoint share this connection). Without the lock, that
+        # thread's cursor can still be mid-statement at the SQLite C-API
+        # level when executescript() below issues its implicit COMMIT,
+        # producing "cannot commit transaction - SQL statements in progress"
+        # on Ubuntu CI 3.40. _lock is an RLock, so self.store() below
+        # re-enters fine.
+        with self._lock:
+            if clear_existing:
+                # Older SQLite (Ubuntu CI 3.40) is strict about open prepared
+                # statements at COMMIT time. Force-finalize any Cursor objects
+                # that may still be unreaped from init (_refresh_hot_cache,
+                # schema migrations) or deferred startup. CPython's refcount
+                # GC usually handles this synchronously, but a brief delay
+                # between cursor scope-out and reclamation is enough to lose
+                # the race. gc.collect() makes it deterministic; on newer
+                # SQLite it's a harmless ~ms no-op.
+                gc.collect()
+                # Atomic clear via executescript: BEGIN/DELETE/COMMIT batched
+                # through sqlite3_exec, which finalizes each prepared statement
+                # before the next runs.
+                script = ["BEGIN;", "DELETE FROM memories;"]
+                if self._vec_available:
+                    script.append("DELETE FROM memories_vec;")
+                script.extend(["DELETE FROM edges;", "COMMIT;"])
                 try:
-                    self._conn.executescript("ROLLBACK;")
-                except Exception:
-                    pass
-                raise
+                    self._conn.executescript(" ".join(script))
+                except Exception as e:
+                    logger.debug("Import clear failed, rolling back: %s", e)
+                    try:
+                        self._conn.executescript("ROLLBACK;")
+                    except Exception:
+                        pass
+                    raise
 
-        imported = 0
-        for node_data in nodes:
-            try:
-                self.store(
-                    content=node_data["content"],
-                    session_id=node_data.get("metadata", {}).get("session_id"),
-                    metadata=node_data.get("metadata"),
-                    ttl_seconds=node_data.get("ttl_seconds"),
-                    skip_inference=True,
-                )
-                imported += 1
-            except Exception as e:
-                logger.debug(f"Import failed for node: {e}")
+            imported = 0
+            for node_data in nodes:
+                try:
+                    self.store(
+                        content=node_data["content"],
+                        session_id=node_data.get("metadata", {}).get("session_id"),
+                        metadata=node_data.get("metadata"),
+                        ttl_seconds=node_data.get("ttl_seconds"),
+                        skip_inference=True,
+                    )
+                    imported += 1
+                except Exception as e:
+                    logger.debug(f"Import failed for node: {e}")
 
         return {
             "filepath": str(filepath),

--- a/src/omega/sqlite_store/_search.py
+++ b/src/omega/sqlite_store/_search.py
@@ -28,14 +28,23 @@ class SearchMixin:
     """Search, retrieval, and caching methods extracted from SQLiteStore."""
 
     def _vec_query(self, embedding: List[float], limit: int = 10) -> List[tuple]:
-        """Query the sqlite-vec virtual table. Returns [(rowid, distance), ...]."""
+        """Query the sqlite-vec virtual table. Returns [(rowid, distance), ...].
+
+        Holds ``self._lock`` for the duration: sqlite-vec's vec0 virtual table
+        keeps C-level prepared-statement state on the connection, and using
+        ``self._conn`` from a non-main thread without the lock races against
+        concurrent writers to ``memories_vec`` (issue #58: macOS Python
+        3.12/3.14 SIGSEGV in ``_pysqlite_query_execute`` under concurrent
+        ``store()``).
+        """
         if not self._vec_available:
             return []
         try:
-            rows = self._conn.execute(
-                "SELECT rowid, distance FROM memories_vec WHERE embedding MATCH ? AND k = ?",
-                (_serialize_f32(embedding), limit),
-            ).fetchall()
+            with self._lock:
+                rows = self._conn.execute(
+                    "SELECT rowid, distance FROM memories_vec WHERE embedding MATCH ? AND k = ?",
+                    (_serialize_f32(embedding), limit),
+                ).fetchall()
             return rows
         except Exception as e:
             logger.debug(f"Vec query failed: {e}")
@@ -671,28 +680,34 @@ class SearchMixin:
         """Find semantically similar memories by embedding.
 
         Filters out expired and superseded memories automatically.
+
+        Holds ``self._lock`` for the duration (issue #58): from a background
+        thread (e.g. bridge's auto-relate worker), reading via ``self._conn``
+        without the lock races concurrent writers on ``memories`` /
+        ``memories_vec`` and SIGSEGVs in sqlite-vec C code on macOS.
         """
         if not self._vec_available or not embedding:
             return []
 
-        # Over-fetch to account for filtered results
-        vec_results = self._vec_query(embedding, limit=limit * 2)
-        results = []
-        for rowid, distance in vec_results:
-            row = self._conn.execute(
-                """SELECT node_id, content, metadata, created_at,
-                          access_count, last_accessed, ttl_seconds
-                   FROM memories WHERE id = ?""",
-                (rowid,),
-            ).fetchone()
-            if row:
-                result = self._row_to_result(row)
-                if result.is_expired() or result.metadata.get("superseded"):
-                    continue
-                result.relevance = 1.0 - distance
-                results.append(result)
-                if len(results) >= limit:
-                    break
+        with self._lock:
+            # Over-fetch to account for filtered results
+            vec_results = self._vec_query(embedding, limit=limit * 2)
+            results = []
+            for rowid, distance in vec_results:
+                row = self._conn.execute(
+                    """SELECT node_id, content, metadata, created_at,
+                              access_count, last_accessed, ttl_seconds
+                       FROM memories WHERE id = ?""",
+                    (rowid,),
+                ).fetchone()
+                if row:
+                    result = self._row_to_result(row)
+                    if result.is_expired() or result.metadata.get("superseded"):
+                        continue
+                    result.relevance = 1.0 - distance
+                    results.append(result)
+                    if len(results) >= limit:
+                        break
         return results
 
     def get_timeline(self, days: int = 7, limit_per_day: int = 10) -> Dict[str, List[MemoryResult]]:

--- a/tests/test_concurrent_store_no_sigsegv.py
+++ b/tests/test_concurrent_store_no_sigsegv.py
@@ -1,0 +1,88 @@
+"""Regression test for issue #58: store() SIGSEGVs under concurrency.
+
+The reporter showed 8 workers × 40 stores = 320 concurrent store() calls
+reliably crashed _sqlite3 _pysqlite_query_execute on macOS Python 3.12/3.14.
+Root cause: bridge's auto-relate daemon thread called find_similar()/
+_vec_query() on the shared sqlite connection without serialization against
+the calling-thread writes; sqlite-vec's vec0 C state corrupted under
+concurrent access.
+
+Test strategy: SIGSEGV is uncatchable in-process — the test worker dies and
+pytest gets an opaque worker-crash report. Run the stress in a subprocess
+and assert clean exit instead.
+"""
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+STRESS_SCRIPT = r"""
+import os
+import sys
+import threading
+from pathlib import Path
+
+# Force a non-default OMEGA_HOME so the test never touches a real DB.
+os.environ["OMEGA_HOME"] = sys.argv[1]
+os.environ.setdefault("OMEGA_SKIP_EMBEDDINGS", "1")  # hash fallback — no ONNX dependency
+
+from omega import bridge
+from omega.sqlite_store import SQLiteStore
+
+# Reuse one store across workers — that's the real-world MCP/CLI shape and
+# the exact configuration the reporter crashed on.
+store = SQLiteStore()
+bridge._store = store  # bridge module-level singleton
+
+N_WORKERS = 8
+PER_WORKER = 40
+
+def _worker(worker_id: int) -> None:
+    for i in range(PER_WORKER):
+        bridge.auto_capture(
+            content=f"stress worker {worker_id} write {i} unique-{worker_id * 1000 + i}",
+            event_type="observation",
+            session_id=f"stress-{worker_id}",
+        )
+
+threads = [threading.Thread(target=_worker, args=(w,)) for w in range(N_WORKERS)]
+for t in threads:
+    t.start()
+for t in threads:
+    t.join()
+
+# Wait briefly for any straggling auto-relate daemon threads, then close.
+# close() joins registered background threads — this is where stale cursors
+# would surface as a use-after-close segfault if locking is wrong.
+store.close()
+print(f"OK: {N_WORKERS * PER_WORKER} concurrent stores completed cleanly")
+"""
+
+
+@pytest.mark.timeout(120)
+def test_concurrent_store_no_sigsegv():
+    """8 workers × 40 stores = 320 concurrent calls, subprocess-isolated.
+
+    Regression coverage for issue #58. Lock-only is necessary (single-conn
+    architecture); without the find_similar/_vec_query lock, this reliably
+    SIGSEGVs on macOS Py3.12+ within seconds.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        result = subprocess.run(
+            [sys.executable, "-c", STRESS_SCRIPT, tmp],
+            capture_output=True,
+            text=True,
+            timeout=90,
+        )
+
+    # SIGSEGV on POSIX = negative returncode -11; any nonzero is a fail.
+    assert result.returncode == 0, (
+        f"Concurrent store subprocess crashed (returncode={result.returncode}).\n"
+        f"stdout: {result.stdout!r}\n"
+        f"stderr: {result.stderr!r}"
+    )
+    assert "OK:" in result.stdout, f"Expected OK marker; got: {result.stdout!r}"


### PR DESCRIPTION
## Summary
Two related reliability fixes:
1. **Sprint 2 (`38e64e7`)**: `import_from_file` cursor-race against deferred-startup thread (Sprint 0 was necessary but not sufficient).
2. **Issue #58 (`0a79f1c`)**: `find_similar` / `_vec_query` race against concurrent writes — reporter's 8×40 stress reliably SIGSEGVs on macOS Py3.12/3.14.

## #58 root cause
bridge.py's auto-relate daemon thread calls `find_similar` → `_vec_query` → `self._conn.execute()` on the sqlite-vec virtual table **without `self._lock`**. Main-thread writes (locked) race the daemon's vec0 prepared statement at the SQLite C level → corrupted state → `_pysqlite_query_execute` segfault.

## Fix
- `_vec_query` + `find_similar`: wrap in `with self._lock:` (RLock, reentrant).
- `bridge._schedule_auto_relate`: add `OMEGA_AUTO_RELATE` env opt-out (parity with `OMEGA_ENTITY_EXTRACTION`).
- `import_from_file`: `with self._lock:` + `gc.collect()` (Sprint 2).

## Test plan
- [x] Existing 223-test suite green locally on 3.11.
- [x] `tests/test_concurrent_store_no_sigsegv.py` — new subprocess-based stress (8×40 stores). Subprocess isolation required because SIGSEGV is uncatchable in-process.
- [ ] Full CI matrix (3.11/3.12/3.13) — Ubuntu SQLite 3.40 path + concurrent-store stress.

## Out of scope (carry-forward)
- Full `_search.py` audit for other unprotected `self._conn.execute` read sites (Sprint 4 candidate).
- omega-main's `bridge/_core.py:_schedule_auto_relate` needs the identical env opt-out + locking (separate PR in private repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)