### PR TITLE
fix(hooks): stop ADD-GUARD blocking ordinary commits via the -a detector

### DIFF
--- a/src/omega/hooks/pre_add_guard.py
+++ b/src/omega/hooks/pre_add_guard.py
@@ -11,6 +11,7 @@ dirty worktree changes from other agents or prior sessions.
 import json
 import os
 import re
+import shlex
 import time
 import traceback
 from datetime import datetime
@@ -48,13 +49,69 @@ def _log_timing(hook_name, elapsed_ms):
         pass
 
 
+# Options to `git commit` whose following token is a value that may itself
+# contain dashes (messages, paths, authors, dates, refs). Their value token
+# must be skipped so it is never mistaken for a `-a` flag.
+_COMMIT_VALUE_OPTS = {
+    "-m", "--message", "-F", "--file", "-C", "--reuse-message",
+    "-c", "--reedit-message", "-t", "--template",
+    "--author", "--date", "--fixup", "--squash",
+}
+
+
+def _commit_has_all_flag(command):
+    """True if *command* contains a `git commit` carrying an -a/--all flag.
+
+    Tokenizes with shlex so dash-text inside quoted messages or paths
+    (e.g. -m "fix the-hard-way", -F some/path) is never mistaken for a
+    `-a` flag — that false positive is why ordinary commits got blocked.
+    Falls back to a flag-anchored regex if quotes are unbalanced.
+    """
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        # Unbalanced quotes: match -a/--all only as a flag token, never as
+        # arbitrary -...a text embedded inside a word.
+        return bool(re.search(
+            r"\bgit\s+commit\b(?:\s+-(?!-)[a-zA-Z]*a[a-zA-Z]*|\s+--all)(?=\s|$)",
+            command,
+        ))
+
+    i, n = 0, len(tokens)
+    while i < n:
+        if tokens[i] == "git" and i + 1 < n and tokens[i + 1] == "commit":
+            j = i + 2
+            while j < n:
+                tok = tokens[j]
+                if tok in (";", "&", "&&", "|", "||"):
+                    break  # start of a chained command
+                if tok == "--all":
+                    return True
+                if tok == "--":
+                    break  # end of options; remainder are pathspecs
+                if tok.startswith("--"):
+                    if tok.split("=", 1)[0] in _COMMIT_VALUE_OPTS and "=" not in tok:
+                        j += 1  # consume value token
+                elif tok.startswith("-") and len(tok) > 1:
+                    if "a" in tok[1:]:
+                        return True  # -a / -am / -va etc.
+                    if tok in _COMMIT_VALUE_OPTS:
+                        j += 1  # consume value token
+                # else: non-option token (subject / pathspec) — ignore
+                j += 1
+            i = j
+            continue
+        i += 1
+    return False
+
+
 def _is_broad_add(command):
     """Detect git add . / git add -A / git add --all / git commit -a patterns."""
     # git add . or git add -A or git add --all
     if re.search(r"\bgit\s+add\s+(\.\s*$|-A\b|--all\b)", command):
         return True
     # git commit -a / git commit -am
-    if re.search(r"\bgit\s+commit\s+.*-[a-zA-Z]*a", command):
+    if _commit_has_all_flag(command):
         return True
     return False
 
@@ -90,7 +147,7 @@ def main():
 
     # Only trigger on git add or git commit -a
     is_git_add = re.search(r"\bgit\s+add\b", command)
-    is_commit_a = re.search(r"\bgit\s+commit\s+.*-[a-zA-Z]*a", command)
+    is_commit_a = _commit_has_all_flag(command)
     if not is_git_add and not is_commit_a:
         return
 


### PR DESCRIPTION
## Problem

`_is_broad_add()` (and the `is_commit_a` trigger in `main()`) in
`src/omega/hooks/pre_add_guard.py` detect `git commit -a` with:

```python
re.search(r"\bgit\s+commit\s+.*-[a-zA-Z]*a", command)
```

The `.*` before `-[a-zA-Z]*a` makes the pattern match **any** dash-word
ending in the letter `a` *anywhere* in the command — not just an `-a` flag.
So it false-positives on perfectly ordinary commits whose message or path
contains such text, blocking them with
`[ADD-GUARD] BLOCKED: broad staging command detected`:

```
git commit -m "fix: learned-the-hard-way"   # matches "-ha" in "hard"
git commit -m "support -a parsing"
git commit --amend -m "x"                    # matches "-a" in "--amend"
git commit -F path/to/some-area/msg.txt      # path with a -…a segment
```

It even fires on `git commit --amend`, which carries no `-a` flag at all.

## Fix

Replace the regex with `_commit_has_all_flag()`, which tokenizes the command
with `shlex` (respecting quotes) and inspects the real `git commit` argument
tokens:

- flags only a genuine `-a` / `-am` / `-va` / `--all`
- skips the value token after value-taking options (`-m`, `-F`, `-C`, `-c`,
  `-t`, `--message`, `--file`, `--author`, `--date`, `--fixup`, `--squash`)
  so message/path text is never scanned as flags
- falls back to a flag-anchored regex when quotes are unbalanced

No change to the `git add .` / `-A` / `--all` detection.

## Verified

A 23-case battery — real `-a`/`--all` variants still blocked; messages,
paths, `--amend`, and `-F file` no longer blocked; unbalanced-quote fallback
correct in both directions — all pass.

| command | before | after |
|---|---|---|
| `git commit -a` | blocked | blocked ✅ |
| `git commit -am 'x'` | blocked | blocked ✅ |
| `git commit --all` | blocked | blocked ✅ |
| `git add .` | blocked | blocked ✅ |
| `git commit -m "…the-hard-way"` | **blocked** ✗ | allowed ✅ |
| `git commit --amend -m x` | **blocked** ✗ | allowed ✅ |
| `git commit -F path/msg.txt` | path-dependent ✗ | allowed ✅ |

## Note for maintainers

If the packaged hook-server daemon carries its own copy of this detector
(the distributed build has the same two
`re.search(r"\bgit\s+commit\s+.*-[a-zA-Z]*a", …)` sites in
`server/hook_server/guards.py`), it needs the identical change — that copy
isn't in this public repo, so this PR only patches the `hooks/` fallback.
