### PR TITLE
fix: preserve per-item batch store fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ Changelog = "https://github.com/omega-memory/omega/blob/main/CHANGELOG.md"
 Issues = "https://github.com/omega-memory/omega/issues"
 
 [project.optional-dependencies]
-server = ["mcp>=1.0.0", "starlette>=0.36.0", "uvicorn>=0.27.0"]
+server = ["mcp>=1.0.0,<2.0.0", "starlette>=0.36.0", "uvicorn>=0.27.0"]
 encrypt = ["cryptography>=41.0.0", "keyring>=25.0.0"]
 full = [
     "omega-memory[server]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ line-length = 120
 
 [tool.ruff.lint]
 # Pre-existing issues to clean up incrementally
+select = ["E4", "E7", "E9", "F"]
 ignore = [
     "E402",   # module-import-not-at-top (lazy imports by design)
     "E721",   # type-comparison (pre-existing)

--- a/src/omega/server/tool_schemas.py
+++ b/src/omega/server/tool_schemas.py
@@ -55,9 +55,36 @@ TOOL_SCHEMAS = [
                     "enum": ["active", "superseded", "speculative", "archived"],
                     "description": "Memory lifecycle status. Default 'active'. Use 'speculative' for unverified claims, 'archived' for intentionally preserved but inactive.",
                 },
-                "items": {"type": "array", "items": {"type": "object"}, "description": "Batch mode: list of {content, event_type, metadata} dicts. When provided, stores all items. Other top-level params ignored."},
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "content": {"type": "string", "description": "Memory content"},
+                            "event_type": {"type": "string", "description": "Per-item memory type"},
+                            "metadata": {"type": "object", "description": "Per-item additional metadata"},
+                            "session_id": {"type": "string"},
+                            "project": {"type": "string"},
+                            "priority": {"type": "integer", "minimum": 1, "maximum": 5},
+                            "entity_id": {"type": "string"},
+                            "agent_type": {"type": "string"},
+                            "derived_from": {"type": "string"},
+                            "source_uri": {"type": "string"},
+                            "status": {
+                                "type": "string",
+                                "enum": ["active", "superseded", "speculative", "archived"],
+                            },
+                        },
+                        "required": ["content"],
+                    },
+                    "description": "Batch mode. Each item is stored with its own fields. Other request-level fields are ignored.",
+                },
             },
-            "required": ["content"],
+            "anyOf": [
+                {"required": ["content"]},
+                {"required": ["text"]},
+                {"required": ["items"]},
+            ],
         },
     },
     {

--- a/src/omega/sqlite_store/_store.py
+++ b/src/omega/sqlite_store/_store.py
@@ -505,13 +505,41 @@ class StoreMixin:
         # acquisition overhead (RLock allows store() to re-enter).
         with self._lock:
             for item in items:
+                # Batch items expose the same metadata-backed fields as a
+                # direct store() call. Copy before merging so callers do not
+                # see their metadata mappings rewritten in place.
+                metadata = dict(item.get("metadata") or {})
+                for field in (
+                    "event_type",
+                    "type",
+                    "priority",
+                    "project",
+                    "referenced_date",
+                    "entity_id",
+                    "agent_type",
+                    "derived_from",
+                    "source_uri",
+                    "status",
+                    "sensitivity",
+                ):
+                    if field in item and item[field] is not None:
+                        metadata[field] = item[field]
+
                 node_id = self.store(
                     content=item["content"],
                     session_id=item.get("session_id"),
-                    metadata=item.get("metadata"),
+                    metadata=metadata,
                     embedding=item.get("embedding"),
                     dependencies=item.get("dependencies"),
                     ttl_seconds=item.get("ttl_seconds"),
+                    graphs=item.get("graphs"),
+                    skip_inference=item.get("skip_inference", False),
+                    entity_id=item.get("entity_id"),
+                    agent_type=item.get("agent_type"),
+                    derived_from=item.get("derived_from"),
+                    source_uri=item.get("source_uri"),
+                    status=item.get("status"),
+                    sensitivity=item.get("sensitivity"),
                 )
                 ids.append(node_id)
         # Single cache invalidation after all inserts

--- a/tests/test_batch_store_handler.py
+++ b/tests/test_batch_store_handler.py
@@ -21,6 +21,44 @@ async def test_batch_store_multiple_items():
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("_reset_bridge")
+async def test_batch_store_persists_per_item_event_types():
+    """The MCP batch path must not collapse item types to the default."""
+    from omega.server.handlers import handle_omega_store
+    from omega.bridge import _get_store
+
+    result = await handle_omega_store(
+        {
+            "items": [
+                {
+                    "content": "MCP batch decision field parity",
+                    "event_type": "decision",
+                    "session_id": "batch-field-parity",
+                    "skip_inference": True,
+                },
+                {
+                    "content": "MCP batch lesson field parity",
+                    "event_type": "lesson_learned",
+                    "session_id": "batch-field-parity",
+                    "skip_inference": True,
+                },
+            ]
+        }
+    )
+
+    assert not result.get("isError")
+    rows = _get_store()._conn.execute(
+        """SELECT content, event_type FROM memories
+           WHERE session_id = ? ORDER BY content""",
+        ("batch-field-parity",),
+    ).fetchall()
+    assert rows == [
+        ("MCP batch decision field parity", "decision"),
+        ("MCP batch lesson field parity", "lesson_learned"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_batch_store_empty_list():
     """omega_store(items=[]) returns empty result, not error."""
     from omega.server.handlers import handle_omega_store
@@ -38,3 +76,31 @@ async def test_batch_store_invalid_type():
 
     result = await handle_omega_store({"items": "not a list"})
     assert result.get("isError") is True
+
+
+def test_omega_store_schema_documents_batch_items():
+    """The MCP schema accepts items-only requests and exposes item fields."""
+    from omega.server.tool_schemas import TOOL_SCHEMAS
+
+    schema = next(tool for tool in TOOL_SCHEMAS if tool["name"] == "omega_store")["inputSchema"]
+    item_schema = schema["properties"]["items"]["items"]
+
+    assert item_schema["required"] == ["content"]
+    assert {
+        "content",
+        "event_type",
+        "metadata",
+        "session_id",
+        "project",
+        "priority",
+        "entity_id",
+        "agent_type",
+        "derived_from",
+        "source_uri",
+        "status",
+    } <= item_schema["properties"].keys()
+    assert {tuple(option["required"]) for option in schema["anyOf"]} == {
+        ("content",),
+        ("text",),
+        ("items",),
+    }

--- a/tests/test_context_packet.py
+++ b/tests/test_context_packet.py
@@ -2,12 +2,17 @@
 
 import ast
 
+import pytest
+
 from omega.server.context_handlers import (
     build_context_packet,
     handle_context_packet,
     _estimate_tokens,
     _render_context_packet,
 )
+
+
+pytestmark = pytest.mark.usefixtures("_reset_bridge")
 
 
 def _payload(resp: dict) -> dict:

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -879,6 +879,81 @@ class TestCRUDComprehensive:
         results = store.get_by_session("batch-sess")
         assert len(results) == 2
 
+    def test_batch_store_preserves_per_item_fields(self, store):
+        parent_id = store.store(
+            content="parent for batch field parity",
+            metadata={"event_type": "memory"},
+            skip_inference=True,
+        )
+        items = [
+            {
+                "content": "batch decision with explicit fields",
+                "event_type": "decision",
+                "priority": 5,
+                "project": "/tmp/batch-project",
+                "entity_id": "batch-entity",
+                "agent_type": "planner",
+                "derived_from": parent_id,
+                "source_uri": "https://example.test/decision",
+                "status": "speculative",
+                "skip_inference": True,
+                "metadata": {
+                    "event_type": "memory",
+                    "priority": 1,
+                    "entity_id": "metadata-entity",
+                    "custom": "preserved",
+                },
+            },
+            {
+                "content": "batch lesson with explicit type",
+                "event_type": "lesson_learned",
+                "priority": 2,
+                "skip_inference": True,
+            },
+        ]
+
+        decision_id, lesson_id = store.batch_store(items)
+
+        decision = store._conn.execute(
+            """SELECT event_type, priority, project, entity_id, agent_type,
+                      memory_type, derived_from, source_uri, status, metadata
+               FROM memories WHERE node_id = ?""",
+            (decision_id,),
+        ).fetchone()
+        lesson = store._conn.execute(
+            "SELECT event_type, priority, memory_type FROM memories WHERE node_id = ?",
+            (lesson_id,),
+        ).fetchone()
+        edge = store._conn.execute(
+            """SELECT 1 FROM edges
+               WHERE source_id = ? AND target_id = ? AND edge_type = 'derived_from'""",
+            (decision_id, parent_id),
+        ).fetchone()
+
+        assert decision[:9] == (
+            "decision",
+            5,
+            "/tmp/batch-project",
+            "batch-entity",
+            "planner",
+            "semantic",
+            parent_id,
+            "https://example.test/decision",
+            "speculative",
+        )
+        decision_metadata = json.loads(decision[9])
+        assert decision_metadata["event_type"] == "decision"
+        assert decision_metadata["priority"] == 5
+        assert decision_metadata["entity_id"] == "batch-entity"
+        assert decision_metadata["custom"] == "preserved"
+        assert lesson == ("lesson_learned", 2, "procedural")
+        assert edge == (1,)
+
+        # Normalization must not rewrite the caller's metadata mapping.
+        assert items[0]["metadata"]["event_type"] == "memory"
+        assert items[0]["metadata"]["priority"] == 1
+        assert items[0]["metadata"]["entity_id"] == "metadata-entity"
+
 
 class TestDeduplicationComprehensive:
     """Thorough dedup coverage."""


### PR DESCRIPTION
Closes #70.

Summary:
- preserve per-item event_type, priority, project, entity, provenance, and status fields in batch_store
- keep explicit top-level values authoritative over copied metadata
- document the per-item MCP schema and accept items-only requests
- add storage and end-to-end MCP regressions

Fresh-install and CI hardening:
- make the intended Ruff rule baseline explicit across Ruff 0.15 and 0.16
- constrain the server dependency to the compatible MCP 1.x API
- isolate context-packet tests from the process-wide bridge singleton

Verification:
- 9 focused batch-store tests passed
- 25 combined batch/context regression tests passed
- full public suite: 1,583 passed, 12 skipped, 1 deselected
- Ruff 0.15.1 and 0.16.1 both pass