### PR TITLE
fix: block private artifacts from public releases

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -25,9 +25,12 @@ import os
 import re
 import subprocess
 import sys
+import tarfile
 import tempfile
 import venv
+import zipfile
 from pathlib import Path
+from pathlib import PurePosixPath
 
 REPO = Path(__file__).resolve().parent.parent
 PYPROJECT = REPO / "pyproject.toml"
@@ -126,6 +129,78 @@ def build() -> tuple[Path, Path]:
     return wheels[0], sdists[0]
 
 
+def _private_archive_members(names: list[str]) -> list[str]:
+    """Return archive members that would expose a private Pro distribution."""
+    offenders = []
+    for name in names:
+        parts = [part.lower() for part in PurePosixPath(name.replace("\\", "/")).parts]
+        filename = parts[-1] if parts else ""
+        if "omega_platform" in parts or "omega_platform.py" in parts:
+            offenders.append(name)
+        elif filename.endswith(".whl"):
+            # A public source archive must never carry a bundled wheel, even if
+            # a future private distribution uses a different filename.
+            offenders.append(name)
+        elif any(filename.startswith(prefix) for prefix in ("omega_memory_pro-", "omega-memory-pro-")):
+            offenders.append(name)
+    return offenders
+
+
+def _private_dependencies(metadata: str) -> list[str]:
+    """Return private distribution requirements from wheel/sdist metadata."""
+    offenders = []
+    for line in metadata.splitlines():
+        if not line.lower().startswith("requires-dist:"):
+            continue
+        requirement = line.split(":", 1)[1].strip()
+        normalized = requirement.lower().replace("_", "-")
+        if normalized.startswith(("omega-platform", "omega-memory-pro")):
+            offenders.append(line)
+    return offenders
+
+
+def verify_public_artifact_boundary(wheel: Path, sdist: Path) -> None:
+    """Fail closed if public artifacts contain or depend on private Pro code."""
+    step("Verifying public/Core artifact boundary")
+    violations = []
+
+    if (REPO / "src" / "omega_platform").exists():
+        violations.append("repository contains src/omega_platform")
+    if not wheel.name.startswith("omega_memory-") or wheel.name.startswith("omega_memory_pro-"):
+        violations.append(f"unexpected public wheel name: {wheel.name}")
+    if not sdist.name.startswith("omega_memory-") or sdist.name.startswith("omega_memory_pro-"):
+        violations.append(f"unexpected public sdist name: {sdist.name}")
+
+    with zipfile.ZipFile(wheel) as archive:
+        wheel_names = archive.namelist()
+        violations.extend(f"wheel member: {name}" for name in _private_archive_members(wheel_names))
+        metadata_names = [name for name in wheel_names if name.endswith(".dist-info/METADATA")]
+        if len(metadata_names) != 1:
+            violations.append(f"wheel contains {len(metadata_names)} METADATA files")
+        else:
+            metadata = archive.read(metadata_names[0]).decode("utf-8", errors="replace")
+            violations.extend(f"wheel dependency: {line}" for line in _private_dependencies(metadata))
+
+    with tarfile.open(sdist, "r:gz") as archive:
+        sdist_names = archive.getnames()
+        violations.extend(f"sdist member: {name}" for name in _private_archive_members(sdist_names))
+        metadata_members = [member for member in archive.getmembers() if member.name.endswith("/PKG-INFO")]
+        if len(metadata_members) != 1:
+            violations.append(f"sdist contains {len(metadata_members)} PKG-INFO files")
+        else:
+            metadata_file = archive.extractfile(metadata_members[0])
+            if metadata_file is None:
+                violations.append("sdist PKG-INFO is unreadable")
+            else:
+                metadata = metadata_file.read().decode("utf-8", errors="replace")
+                violations.extend(f"sdist dependency: {line}" for line in _private_dependencies(metadata))
+
+    if violations:
+        detail = "\n  ".join(violations)
+        sys.exit(f"Public artifact boundary violation:\n  {detail}")
+    print("  OK: Core-only archives; no private namespace, bundled wheel, or Pro dependency")
+
+
 def verify(wheel: Path, expected_version: str) -> None:
     step("Verifying wheel in clean venv")
     with tempfile.TemporaryDirectory(prefix="omega-mem-verify-") as tmp:
@@ -185,6 +260,7 @@ def main() -> int:
     preflight(args.version)
     bump_version(args.version)
     wheel, sdist = build()
+    verify_public_artifact_boundary(wheel, sdist)
     verify(wheel, args.version)
 
     if args.dry_run:

--- a/tests/test_release_artifact_boundary.py
+++ b/tests/test_release_artifact_boundary.py
@@ -1,0 +1,86 @@
+"""Release-time guards for the public Core/Pro package boundary."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+_RELEASE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "release.py"
+_SPEC = importlib.util.spec_from_file_location("omega_release", _RELEASE_PATH)
+assert _SPEC and _SPEC.loader
+release = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(release)
+
+
+def _write_wheel(path: Path, *, extra_members: dict[str, str] | None = None, dependency: str | None = None) -> None:
+    metadata = "Metadata-Version: 2.4\nName: omega-memory\nVersion: 9.9.9\n"
+    if dependency:
+        metadata += f"Requires-Dist: {dependency}\n"
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("omega/__init__.py", "")
+        archive.writestr("omega/server/mcp_server.py", "import omega_platform  # optional integration\n")
+        archive.writestr("omega_memory-9.9.9.dist-info/METADATA", metadata)
+        for name, content in (extra_members or {}).items():
+            archive.writestr(name, content)
+
+
+def _write_sdist(path: Path, *, extra_members: dict[str, str] | None = None, dependency: str | None = None) -> None:
+    metadata = "Metadata-Version: 2.4\nName: omega-memory\nVersion: 9.9.9\n"
+    if dependency:
+        metadata += f"Requires-Dist: {dependency}\n"
+    members = {
+        "omega_memory-9.9.9/PKG-INFO": metadata,
+        "omega_memory-9.9.9/src/omega/__init__.py": "",
+        **(extra_members or {}),
+    }
+    with tarfile.open(path, "w:gz") as archive:
+        for name, content in members.items():
+            data = content.encode()
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            archive.addfile(info, io.BytesIO(data))
+
+
+def _artifacts(tmp_path: Path, **kwargs) -> tuple[Path, Path]:
+    wheel = tmp_path / "omega_memory-9.9.9-py3-none-any.whl"
+    sdist = tmp_path / "omega_memory-9.9.9.tar.gz"
+    _write_wheel(wheel, extra_members=kwargs.get("wheel_members"), dependency=kwargs.get("wheel_dependency"))
+    _write_sdist(sdist, extra_members=kwargs.get("sdist_members"), dependency=kwargs.get("sdist_dependency"))
+    return wheel, sdist
+
+
+def test_boundary_accepts_core_with_optional_pro_import_references(tmp_path):
+    wheel, sdist = _artifacts(tmp_path)
+
+    release.verify_public_artifact_boundary(wheel, sdist)
+
+
+def test_boundary_rejects_private_namespace_in_wheel(tmp_path):
+    wheel, sdist = _artifacts(tmp_path, wheel_members={"omega_platform/license.py": ""})
+
+    with pytest.raises(SystemExit, match=r"wheel member: omega_platform/license\.py"):
+        release.verify_public_artifact_boundary(wheel, sdist)
+
+
+def test_boundary_rejects_bundled_wheel_in_sdist(tmp_path):
+    wheel, sdist = _artifacts(
+        tmp_path,
+        sdist_members={"omega_memory-9.9.9/vendor/omega_memory_pro-9.9.9-py3-none-any.whl": "private"},
+    )
+
+    with pytest.raises(SystemExit, match=r"sdist member: .*omega_memory_pro.*\.whl"):
+        release.verify_public_artifact_boundary(wheel, sdist)
+
+
+@pytest.mark.parametrize("artifact", ["wheel", "sdist"])
+def test_boundary_rejects_private_distribution_dependency(tmp_path, artifact):
+    wheel, sdist = _artifacts(tmp_path, **{f"{artifact}_dependency": "omega-platform>=1.6"})
+
+    with pytest.raises(SystemExit, match=rf"{artifact} dependency: Requires-Dist: omega-platform"):
+        release.verify_public_artifact_boundary(wheel, sdist)


### PR DESCRIPTION
Follow-up hardening after #70.

## Summary
- fail closed when a public wheel or source archive contains the private omega_platform namespace
- reject bundled wheel files and omega-platform / omega-memory-pro dependencies
- keep optional Core-to-Pro import references valid without shipping Pro implementation code
- run the boundary audit before clean-environment installation or any PyPI upload

## Verification
- 8 focused Core/Pro boundary tests passed
- fresh wheel and sdist build passed the new artifact audit
- Ruff and Python syntax checks passed
- full public suite: 1,588 passed, 12 skipped, 1 deselected

This PR does not publish a package or modify the private Pro distribution.