### PR TITLE
fix: remove embedding dedup that silently discarded stores

### DIFF
--- a/src/omega/bridge.py
+++ b/src/omega/bridge.py
@@ -1386,7 +1386,17 @@ def auto_capture(
     )
 
     ttl_str = _human_ttl(ttl)
-    output = f"Stored {node_id} ({event_type}, {ttl_str})"
+    # store() returns a node ID whether it inserted or collapsed into an
+    # existing memory, so report the outcome the store actually took —
+    # "Stored" on a dedup would claim a write that never happened.
+    try:
+        _deduped = store.get_last_store_deduped()
+    except AttributeError:
+        _deduped = False
+    if _deduped:
+        output = f"Deduped → {node_id}"
+    else:
+        output = f"Stored {node_id} ({event_type}, {ttl_str})"
 
     # Surface deep contradiction detection results
     try:

--- a/src/omega/sqlite_store/_base.py
+++ b/src/omega/sqlite_store/_base.py
@@ -262,7 +262,6 @@ class SQLiteStoreBase:
         }
     )
 
-    DEFAULT_EMBEDDING_DEDUP_THRESHOLD = 0.88
     DEFAULT_JACCARD_DEDUP_THRESHOLD = 0.80
 
     # Input size limits (configurable via env vars)
@@ -362,6 +361,12 @@ class SQLiteStoreBase:
 
         # Last contradiction detection results (consume-once, set by store())
         self._last_contradiction_results: list = []
+
+        # Whether the most recent store() collapsed into an existing memory
+        # instead of inserting (consume-once, set by store()). Callers need
+        # this to report "Deduped" rather than claiming a write happened —
+        # store() returns a node ID either way, which is indistinguishable.
+        self._last_store_deduped: bool = False
 
         # Agency Tax: operation latency tracking (arxiv 2602.19320 §4.4)
         self._op_timings: Dict[str, list] = {}

--- a/src/omega/sqlite_store/_store.py
+++ b/src/omega/sqlite_store/_store.py
@@ -37,6 +37,7 @@ class StoreMixin:
     ) -> str:
         """Store a memory. Returns the node ID."""
         _t0_agency = _time.monotonic()
+        self._last_store_deduped = False
         self._total_write_count += 1
         if not content:
             raise StorageError("content must be a non-empty string")
@@ -72,19 +73,21 @@ class StoreMixin:
         content_hash = hashlib.sha256(content.encode()).hexdigest()
         canonical_hash = hashlib.sha256(_canonicalize(content).encode()).hexdigest()
 
-        # Pre-compute embedding dedup outside lock to reduce contention
-        # (vec_query is the expensive part; the UPDATE+commit stays inside the lock)
-        _vec_dedup_candidate = None
-        if embedding and not skip_inference and self._vec_available:
-            try:
-                similar = self._vec_query(embedding, limit=1)
-                if similar:
-                    top_rowid, distance = similar[0]
-                    similarity = 1.0 - distance
-                    if similarity >= self.DEFAULT_EMBEDDING_DEDUP_THRESHOLD:
-                        _vec_dedup_candidate = (top_rowid, similarity)
-            except Exception as e:
-                logger.debug("Embedding dedup pre-check failed: %s", e)
+        # NOTE: embedding-similarity dedup used to run here. It was removed
+        # after measurement showed it had no true-positive yield: it runs
+        # *after* canonical-hash and content-hash dedup, so everything reaching
+        # it is textually novel by construction. Measured over 3,000 real
+        # memories, the 0.88 threshold discarded 334 writes of which only 2
+        # were byte-identical — and those two content-hash dedup already
+        # catches. Sentence embeddings are near-blind to digits, so records
+        # differing only in their numbers (successive benchmark runs, version
+        # counts, metrics) scored ~0.96 and collapsed into each other. No
+        # threshold separates duplicates from distinct content: the most
+        # similar non-identical pair scored 0.9845. Each false positive
+        # silently discarded a write while store() returned the existing node
+        # ID, which callers reported as a successful save.
+        # Do not reintroduce similarity-based dedup without a mechanism that
+        # preserves the incoming content.
 
         with self._lock:
             # Capacity check (inside lock — queries shared connection).
@@ -159,6 +162,7 @@ class StoreMixin:
                 self._commit()
                 self.stats.setdefault("dedup_canonical", 0)
                 self.stats["dedup_canonical"] += 1
+                self._last_store_deduped = True
                 self._record_timing("write", (_time.monotonic() - _t0_agency) * 1000)
                 return canonical_existing[0]
 
@@ -177,26 +181,9 @@ class StoreMixin:
                 self._commit()
                 self.stats.setdefault("dedup_exact", 0)
                 self.stats["dedup_exact"] += 1
+                self._last_store_deduped = True
                 self._record_timing("write", (_time.monotonic() - _t0_agency) * 1000)
                 return existing[0]
-
-            # Embedding-based dedup (vec_query already done outside lock)
-            if _vec_dedup_candidate:
-                try:
-                    top_rowid, _similarity = _vec_dedup_candidate
-                    row = self._exec(
-                        "SELECT node_id FROM memories WHERE id = ?", (top_rowid,)
-                    ).fetchone()
-                    if row:
-                        self._exec(
-                            "UPDATE memories SET access_count = access_count + 1 WHERE id = ?", (top_rowid,)
-                        )
-                        self._commit()
-                        self.stats["embedding_dedup_skips"] += 1
-                        self._record_timing("write", (_time.monotonic() - _t0_agency) * 1000)
-                        return row[0]
-                except Exception as e:
-                    logger.debug("Embedding dedup check failed: %s", e)
 
             # Generate node ID
             node_id = f"mem-{uuid.uuid4().hex[:12]}"
@@ -316,6 +303,17 @@ class StoreMixin:
         results = self._last_contradiction_results
         self._last_contradiction_results = []
         return results
+
+    def get_last_store_deduped(self) -> bool:
+        """Whether the most recent store() collapsed into an existing memory. Consume-once.
+
+        store() returns a node ID whether it inserted or deduped, so callers
+        that report the outcome to a user must check this to avoid claiming a
+        write that never happened.
+        """
+        deduped = self._last_store_deduped
+        self._last_store_deduped = False
+        return deduped
 
     def get_node(self, node_id: str, track_access: bool = True) -> Optional[MemoryResult]:
         """Get a node by ID.

--- a/tests/test_store_dedup_reporting.py
+++ b/tests/test_store_dedup_reporting.py
@@ -1,0 +1,109 @@
+"""Regression tests for the silent-drop store bug.
+
+Embedding-similarity dedup used to collapse textually distinct memories that
+scored above a cosine threshold, discard the incoming content, and return the
+existing node ID — which bridge.py then reported as "Stored". Records that
+differed only in their numbers (successive benchmark runs, version counts,
+metrics) were the worst case, because sentence embeddings are near-blind to
+digits.
+
+The check was also completely ungated here: it compared against the single
+nearest vector neighbour regardless of event_type, agent_type, or project, so
+unrelated memories could absorb each other's content.
+
+These tests pin three properties:
+  1. Content differing only in numbers is stored as distinct memories.
+  2. Memories of different types are never collapsed into one another.
+  3. A store that does collapse into an existing memory says so, rather than
+     claiming a write happened.
+"""
+
+from omega.embedding import generate_embedding
+
+V400 = (
+    "Benchmark run v400 complete. Latency p50 120ms, p95 340ms, "
+    "throughput 810 rps, error rate 0.4 percent."
+)
+V401 = (
+    "Benchmark run v401 complete. Latency p50 96ms, p95 210ms, "
+    "throughput 1150 rps, error rate 0.1 percent."
+)
+
+
+def test_numeric_variants_are_stored_separately(store):
+    """Same prose, different measurements — must not collapse.
+
+    These two strings embed at ~0.96 cosine similarity, well above the old
+    0.88 dedup threshold, so this is the exact case that silently lost data.
+    """
+    first = store.store(
+        content=V400,
+        metadata={"event_type": "memory"},
+        embedding=generate_embedding(V400),
+    )
+    second = store.store(
+        content=V401,
+        metadata={"event_type": "memory"},
+        embedding=generate_embedding(V401),
+    )
+
+    assert first != second, "numeric-only differences must not dedup"
+
+    contents = {
+        store.get_node(first, track_access=False).content,
+        store.get_node(second, track_access=False).content,
+    }
+    assert contents == {V400, V401}, "both versions must be retrievable verbatim"
+
+
+def test_similar_content_of_different_types_stays_separate(store):
+    """The old check ignored event_type entirely — a decision could absorb a lesson."""
+    a = store.store(
+        content=V400,
+        metadata={"event_type": "decision"},
+        embedding=generate_embedding(V400),
+    )
+    b = store.store(
+        content=V401,
+        metadata={"event_type": "lesson_learned"},
+        embedding=generate_embedding(V401),
+    )
+    assert a != b
+
+
+def test_numeric_variant_store_is_not_reported_as_dedup(store):
+    """The insert path must not set the dedup flag."""
+    store.store(
+        content=V400, metadata={"event_type": "memory"}, embedding=generate_embedding(V400)
+    )
+    store.store(
+        content=V401, metadata={"event_type": "memory"}, embedding=generate_embedding(V401)
+    )
+
+    assert store.get_last_store_deduped() is False
+
+
+def test_identical_content_still_dedups_and_reports_it(store):
+    """Exact duplicates should still collapse — and admit that they did."""
+    first = store.store(
+        content=V400, metadata={"event_type": "memory"}, embedding=generate_embedding(V400)
+    )
+    second = store.store(
+        content=V400, metadata={"event_type": "memory"}, embedding=generate_embedding(V400)
+    )
+
+    assert first == second, "byte-identical content should dedup via content hash"
+    assert store.get_last_store_deduped() is True
+
+
+def test_dedup_flag_is_consume_once(store):
+    """A stale flag would mislabel the next insert as a dedup."""
+    store.store(
+        content=V400, metadata={"event_type": "memory"}, embedding=generate_embedding(V400)
+    )
+    store.store(
+        content=V400, metadata={"event_type": "memory"}, embedding=generate_embedding(V400)
+    )
+
+    assert store.get_last_store_deduped() is True
+    assert store.get_last_store_deduped() is False


### PR DESCRIPTION
## The bug

`store()` returned the node ID of an *existing* memory while throwing the incoming content away, and `bridge.py` reported that as `Stored`. Callers had no way to distinguish a real write from a discarded one — a "Stored" message was not proof the content was kept.

## Why the check had no value

Embedding dedup runs *after* canonical-hash and content-hash dedup, so everything reaching it is textually novel by construction.

Measured over 3,000 real memories, the 0.88 threshold discarded **334 writes, of which only 2 were byte-identical** — and content-hash dedup already catches those two one step earlier. No threshold rescues it; the most similar non-identical pair scored **0.9845**:

| threshold | discards | byte-identical | false-positive rate |
|---|---|---|---|
| 0.88 (shipped) | 334 | 2 | 99% |
| 0.95 | 21 | 2 | 90% |
| 0.98 | 8 | 2 | 75% |
| 0.99 | 2 | 2 | 0% (redundant with hash dedup) |

It was also **ungated** — it compared against the single nearest vector neighbour regardless of `event_type`, `agent_type`, or project, so unrelated memories could absorb each other's content (a `decision` could swallow a `lesson_learned`).

Sentence embeddings are near-blind to digits, so the records that most need to stay distinct were the ones that collapsed: successive benchmark runs with identical prose and different measurements embed at ~0.96.

## Honest reporting

`store()` returns a node ID whether it inserted or deduped. A consume-once flag now distinguishes the two, mirroring the existing `get_last_contradiction_results()` pattern. `Deduped → {id}` is an existing contract that consumers already handle, so no downstream changes were needed.

## Retrieval impact: none by design

Removing store-time dedup cannot flood results — near-duplicates are already collapsed at *query* time by `_semantic_dedup()` (cosine 0.92, non-destructive: it drops the lower-scored item). `test_retrieval_golden_set.py::test_identical_content_deduped_at_query` covers exactly this, inserting duplicates that bypass store-time dedup and asserting one result.

## Verification

- 5 new regression tests, which **fail against the pre-fix code** (negative control run via stash) and pass after
- Full suite: **1599 passed, 6 skipped**
- Release artifact-boundary gate: 5 passed