### PR TITLE
fix(server): publish omega.server.validation (fixes Pro handler crash) + release 1.5.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "omega-memory"
-version = "1.5.7"
+version = "1.5.8"
 description = "Cross-model memory for AI agents. Local-first, works with Claude, GPT, Gemini, Cursor, Claw Code, and any MCP client"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/omega/__init__.py
+++ b/src/omega/__init__.py
@@ -10,7 +10,7 @@ For full Claude Code integration (MCP tools, auto-capture, coordination),
 install with: ``pip install omega-memory[server]``
 """
 
-__version__ = "1.5.7"
+__version__ = "1.5.8"
 
 from omega.sqlite_store import SQLiteStore
 from omega.bridge import (

--- a/src/omega/server/handlers.py
+++ b/src/omega/server/handlers.py
@@ -188,32 +188,15 @@ _SAFE_EXPORT_DIR = Path.home() / ".omega"
 # Input validation helpers — prevent path traversal and injection
 # ---------------------------------------------------------------------------
 
-import re as _re
-
-_SAFE_ID_RE = _re.compile(r"^[a-zA-Z0-9._-]+$")
-
-
-def _validate_session_id(session_id: str | None) -> str | None:
-    """Validate session_id to prevent path traversal."""
-    if not session_id:
-        return session_id
-    if ".." in session_id or "/" in session_id or "\\" in session_id:
-        logger.warning("Rejected session_id with path traversal: %s", session_id[:50])
-        return None
-    if not _SAFE_ID_RE.match(session_id):
-        logger.warning("Rejected session_id with invalid chars: %s", session_id[:50])
-        return None
-    return session_id
-
-
-def _validate_entity_id(entity_id: str | None) -> str | None:
-    """Validate entity_id format (alphanumeric, hyphens, dots, underscores)."""
-    if not entity_id:
-        return entity_id
-    if not _SAFE_ID_RE.match(entity_id):
-        logger.warning("Rejected entity_id with invalid chars: %s", entity_id[:50])
-        return None
-    return entity_id
+# Defined in omega.server.validation so that any handler needing them -- here
+# or in the Pro package -- imports one implementation rather than keeping a
+# second copy in step by hand. Security logic that exists twice drifts.
+# The private ``_``-prefixed names are kept as aliases so existing call sites
+# in this module read unchanged.
+from omega.server.validation import (  # noqa: E402
+    validate_entity_id as _validate_entity_id,
+    validate_session_id as _validate_session_id,
+)
 
 
 from omega.server.responses import mcp_response, mcp_error  # noqa: E402

--- a/src/omega/server/validation.py
+++ b/src/omega/server/validation.py
@@ -1,0 +1,52 @@
+"""Core MCP-handler input validators.
+
+These helpers guard agent-supplied identifiers (session_id, entity_id)
+against path traversal and injection before they reach the storage
+layer. They live in Core — not Pro — because every MCP handler that
+takes a session_id or entity_id needs them, and Core-only installs
+must not import Pro modules at handler-load time.
+
+The Pro package re-exports these functions from
+``omega_platform.server.validation`` so existing Pro-side imports
+continue to resolve. Path-level validators (validate_safe_path,
+is_url_scheme) remain Pro-only.
+"""
+
+import logging
+import re
+
+logger = logging.getLogger("omega.server.validation")
+
+_SAFE_ID_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
+
+
+def validate_session_id(session_id: str | None) -> str | None:
+    """Validate session_id to prevent path traversal.
+
+    Returns the cleaned session_id, or None if it contains traversal
+    characters (``..``, ``/``, ``\\``) or characters outside the safe
+    alphanumeric / dot / underscore / hyphen set.
+    """
+    if not session_id:
+        return session_id
+    if ".." in session_id or "/" in session_id or "\\" in session_id:
+        logger.warning("Rejected session_id with path traversal: %s", session_id[:50])
+        return None
+    if not _SAFE_ID_RE.match(session_id):
+        logger.warning("Rejected session_id with invalid chars: %s", session_id[:50])
+        return None
+    return session_id
+
+
+def validate_entity_id(entity_id: str | None) -> str | None:
+    """Validate entity_id format.
+
+    Allows alphanumerics, dots, underscores, and hyphens. Returns the
+    cleaned entity_id, or None if any other character is present.
+    """
+    if not entity_id:
+        return entity_id
+    if not _SAFE_ID_RE.match(entity_id):
+        logger.warning("Rejected entity_id with invalid chars: %s", entity_id[:50])
+        return None
+    return entity_id


### PR DESCRIPTION
## The bug

The Pro package's `omega_platform/server/validation.py` imports `validate_entity_id` and `validate_session_id` from `omega.server.validation` at **module level, unguarded**. That module has never existed in the published Core package.

Reproduced on a real customer install — PyPI `omega-memory` 1.5.7 plus the published `omega-memory-pro` 1.5.5 wheel:

```
omega_platform.server.validation       ModuleNotFoundError
omega_platform.server.coord_handlers   ModuleNotFoundError (same chain)
omega_platform.ingest.handlers         imports, raises when the path runs
omega_platform.knowledge.handlers      imports, raises when the path runs (x3)
```

Calling the paid MCP tools with a licence active:

```
omega_ingest_file      -> ModuleNotFoundError: No module named 'omega.server.validation'
omega_ingest_document  -> ModuleNotFoundError: No module named 'omega.server.validation'
```

**The licence gate fires before the broken import**, so an unlicensed call returns a clean "requires an active Pro license" and never reaches it. Only paying customers hit the crash — which is why nothing caught it.

The affected symbols are the path-traversal and identifier guards.

## The fix

The logic already existed here as `_validate_session_id` / `_validate_entity_id`, private to `omega/server/handlers.py`. This extracts them into `omega/server/validation.py` — **byte-identical to the private repo's copy**, so the two stay reconciled — and re-imports them into `handlers.py` under their original names.

Deliberately not a reimplementation: security logic kept in two places drifts apart. No call site changes.

Pro's own module docstring records that the ID validators moved to Core "so Core handlers can import them without depending on the Pro wheel," and that the Pro-side re-export exists so pre-existing imports "stay green." The move happened in the private repo; the Core half was never published here.

## Verification

| check | result |
|---|---|
| Behaviour vs old inline validators, 14 adversarial inputs | 0 mismatches |
| Full suite | **1599 passed**, 6 skipped, 0 failed |
| ruff | clean |
| All 29 `omega.*` modules the Pro wheel imports, resolved against this build | 0 failures |
| External references to the moved symbols | none |
| Import cycle | none — `validation.py` imports only `logging` and `re` |

End-to-end with the **unchanged** published Pro 1.5.5 wheel, only Core differing:

| | Core 1.5.7 | Core 1.5.8 |
|---|---|---|
| `omega_ingest_file` | crash | works |
| `omega_ingest_document` | crash | works |
| all three imports above | ModuleNotFoundError | OK |

## Release

Second commit bumps to **1.5.8**. 1.5.7 is published and immutable, so the fix needs a new number.

1.5.8 rather than 1.5.7.1: a four-part version is legal PEP 440, but the update checker's parser handled only three components, so `1.5.7.1` would have gone unparsed and silenced update notifications. That parser is being fixed separately; the release shouldn't depend on it. Patch increments can't collide with a future 1.6 — `1.5.99 < 1.6.0`.

## Note for whoever picks this up next

Publishing 1.5.8 does **not** reach existing Pro customers on its own. Pro declares `omega-memory>=1.4.13`, so nothing pulls them onto the fixed Core. Raising Pro's floor to `>=1.5.8` in the next Pro release is what delivers this fix.

Refs singularityjason/omega#92

🤖 Generated with [Claude Code](https://claude.com/claude-code)