### PR TITLE
fix: fail loudly when a memory's vector cannot be stored; make embedding config explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.11] - 2026-08-16
+
+### Fixed
+- **Memory writes no longer report success when the vector is not stored.** A
+  failed `memories_vec` insert — most commonly an embedding-dimension mismatch
+  — was logged at `DEBUG` and swallowed, so `store()` returned an id and a
+  count while the memory was written with no vector and was invisible to every
+  later semantic search. The write now fails loudly and rolls back, so a
+  rejected write leaves no vectorless row behind. `update_node()` had the same
+  bug in a worse form: it deleted the existing vector before inserting the new
+  one, so a swallowed failure discarded a working vector.
+
+### Added
+- Added `OMEGA_EMBEDDING_MODEL`, `OMEGA_EMBEDDING_DIM`,
+  `OMEGA_EMBEDDING_POOLING`, `OMEGA_EMBEDDING_MODEL_DIR`,
+  `OMEGA_EMBEDDING_PAD_TOKEN` and `OMEGA_EMBEDDING_PAD_ID`, read once at import
+  and validated. The embedding dimension, model, pooling strategy and pad token
+  were previously literals across five modules, so multilingual deployments
+  maintained local patches that every upgrade silently reverted. Restart OMEGA
+  after changing them.
+- Opening a store now verifies the configured dimension against the dimension
+  the `memories_vec` table was created with, and refuses to start on a
+  mismatch. `CREATE VIRTUAL TABLE IF NOT EXISTS` keeps the original dimension,
+  so this previously surfaced only as a slow trickle of rejected writes.
+- `pooling=cls` supports CLS-pooled models such as `bge-m3` alongside the
+  default mean pooling.
+
+### Changed
+- `OMEGA_ONNX_MODEL_DIR` is now consulted before the packaged default model
+  directory. It was previously checked only if the default path was missing —
+  and since `omega setup --download-model` installs exactly that path, the
+  override was unreachable on a normal install.
+
 ## [1.5.10] - 2026-08-14
 
 ### Fixed

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -75,6 +75,38 @@ Adds a managed block between `<!-- OMEGA:BEGIN -->` and `<!-- OMEGA:END -->` mar
     source ~/.zshrc
     ```
 
+## Embedding model
+
+The factory model is `bge-small-en-v1.5` — English-only, 384 dimensions. These
+variables are read **once at import**, so restart OMEGA after changing any of
+them.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OMEGA_EMBEDDING_MODEL` | `bge-small-en-v1.5` | Model name. Also selects the default model directory |
+| `OMEGA_EMBEDDING_DIM` | `384` | Vector dimension. Must match both the model and the existing vector tables |
+| `OMEGA_EMBEDDING_POOLING` | `mean` | `mean` or `cls`. CLS-trained models such as `bge-m3` need `cls` |
+| `OMEGA_EMBEDDING_MODEL_DIR` | `~/.cache/omega/models/<model>-onnx` | Explicit ONNX model directory |
+| `OMEGA_EMBEDDING_PAD_TOKEN` | `[PAD]` | Tokenizer padding token |
+| `OMEGA_EMBEDDING_PAD_ID` | `0` | Tokenizer padding id |
+
+!!! warning "The dimension must match the existing store"
+
+    `OMEGA_EMBEDDING_DIM` has to agree with the dimension the vector tables were
+    created with. OMEGA verifies this when it opens a store and **refuses to
+    start** on a mismatch, rather than accepting writes it cannot vectorize.
+
+    Changing the dimension on a store that already holds data requires
+    re-embedding it — the existing vectors are not convertible.
+
+Running a multilingual model, for example:
+
+```bash
+export OMEGA_EMBEDDING_MODEL=bge-m3
+export OMEGA_EMBEDDING_DIM=1024
+export OMEGA_EMBEDDING_POOLING=cls
+```
+
 ## Hooks
 
 OMEGA uses 7 hook processes (batched from 11 handlers) that run automatically during Claude Code sessions. All hooks are **fail-open** — if a hook errors, it logs to `~/.omega/hooks.log` and lets the operation proceed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "omega-memory"
-version = "1.5.10"
+version = "1.5.11"
 description = "Cross-model memory for AI agents. Local-first, works with Claude, GPT, Gemini, Cursor, Claw Code, and any MCP client"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/omega/__init__.py
+++ b/src/omega/__init__.py
@@ -10,7 +10,7 @@ For full Claude Code integration (MCP tools, auto-capture, coordination),
 install with: ``pip install omega-memory[server]``
 """
 
-__version__ = "1.5.10"
+__version__ = "1.5.11"
 
 from omega.sqlite_store import SQLiteStore
 from omega.bridge import (

--- a/src/omega/bridge.py
+++ b/src/omega/bridge.py
@@ -4068,7 +4068,9 @@ def discover_connections(
 
         # Find similar memories
         import struct
-        _EMBED_DIM = 384
+
+        from omega.sqlite_store import EMBEDDING_DIM as _EMBED_DIM
+
         expected_size = _EMBED_DIM * 4  # 4 bytes per float
         if len(emb_row[0]) != expected_size:
             continue

--- a/src/omega/cli.py
+++ b/src/omega/cli.py
@@ -2415,11 +2415,20 @@ def cmd_doctor(args):
         else:
             warn("ONNX Runtime not available, will use fallback")
 
+        from omega.embedding_config import get_embedding_config
+
+        expected_dim = get_embedding_config().dim
         emb = generate_embedding("test embedding")
-        if len(emb) == 384:
-            ok(f"Embedding generation works (384-dim, backend={info.get('backend', 'unknown')})")
+        if len(emb) == expected_dim:
+            ok(
+                f"Embedding generation works ({expected_dim}-dim, "
+                f"backend={info.get('backend', 'unknown')})"
+            )
         else:
-            fail(f"Embedding dimension wrong: {len(emb)} (expected 384)")
+            fail(
+                f"Embedding dimension wrong: {len(emb)} "
+                f"(expected {expected_dim} from OMEGA_EMBEDDING_DIM)"
+            )
     except Exception as e:
         fail(f"Embedding generation failed: {e}")
 

--- a/src/omega/embedding.py
+++ b/src/omega/embedding.py
@@ -2,13 +2,16 @@
 OMEGA Embeddings — ONNX-based embedding generation for semantic search.
 
 Provides:
-- generate_embedding(text) → 384-dim normalized vector
+- generate_embedding(text) → normalized vector at the configured dimension
 - generate_embeddings_batch(texts) → list of vectors
 - Async variants for non-blocking operation
 - LRU cache for repeated queries
 - Hash-based fallback when no ML model available
 
-Uses bge-small-en-v1.5 via ONNX Runtime (~90MB RAM, ~170MB with arena disabled).
+Uses bge-small-en-v1.5 by default via ONNX Runtime (~90MB RAM, ~170MB with arena
+disabled). The model, dimension, pooling and pad token are configurable through
+the OMEGA_EMBEDDING_* variables (see omega.embedding_config) so multilingual
+models such as bge-m3 can be selected without patching this module.
 Falls back to all-MiniLM-L6-v2 if bge model not downloaded, or hash-based pseudo-embeddings if ONNX unavailable.
 """
 
@@ -18,6 +21,8 @@ import hashlib
 import logging
 import math
 import os
+
+from omega.embedding_config import DEFAULT_EMBEDDING_MODEL, get_embedding_config
 
 __all__ = [
     "generate_embedding",
@@ -46,8 +51,14 @@ except ImportError:
 _EMBEDDING_MODEL = None
 _EMBEDDING_BACKEND = None  # "onnx" only (sentence-transformers removed to prevent 7.5GB PyTorch blowup)
 _LOAD_ATTEMPTED = False  # Circuit breaker: don't retry after first failure
-_EMBEDDING_MODEL_NAME = "bge-small-en-v1.5"
-_EMBEDDING_MODEL_VERSION = "v1.5"
+_EMBEDDING_CONFIG = get_embedding_config()
+_EMBEDDING_MODEL_NAME = _EMBEDDING_CONFIG.model_name
+# Version tracks the shipped default only. A configured model has its own
+# versioning we cannot infer, and stamping "v1.5" on it would put a false
+# version in the metadata of every memory it embeds.
+_EMBEDDING_MODEL_VERSION = (
+    "v1.5" if _EMBEDDING_MODEL_NAME == DEFAULT_EMBEDDING_MODEL else "configured"
+)
 _EMBEDDING_CACHE: OrderedDict = OrderedDict()
 _CACHE_MAX = int(os.environ.get("OMEGA_EMBEDDING_CACHE_MAX", "512"))
 _EMBEDDING_CACHE_MAX = _CACHE_MAX
@@ -64,9 +75,9 @@ _UNLOAD_CHECK_INTERVAL_S = 60  # check at most once per 60s
 _FIRST_FAILURE_TIME: float = 0.0  # monotonic timestamp of first failure in current window
 _CIRCUIT_BREAKER_COOLDOWN_S = 300  # 5 minutes
 
-# ONNX model paths (bge-small-en-v1.5 primary, all-MiniLM-L6-v2 fallback)
+# ONNX model paths (configured model primary, all-MiniLM-L6-v2 fallback)
 _ONNX_MODEL_DIR = None
-_ONNX_DEFAULT_DIR = "~/.cache/omega/models/bge-small-en-v1.5-onnx"
+_ONNX_DEFAULT_DIR = _EMBEDDING_CONFIG.model_dir
 _ONNX_FALLBACK_DIR = "~/.cache/omega/models/all-MiniLM-L6-v2-onnx"
 
 # Availability checks (cached)
@@ -110,8 +121,10 @@ def reset_embedding_state():
     _EMBEDDING_BACKEND = None
     _LOAD_ATTEMPTED = False
     _ONNX_MODEL_DIR = None
-    _EMBEDDING_MODEL_NAME = "bge-small-en-v1.5"
-    _EMBEDDING_MODEL_VERSION = "v1.5"
+    _EMBEDDING_MODEL_NAME = _EMBEDDING_CONFIG.model_name
+    _EMBEDDING_MODEL_VERSION = (
+        "v1.5" if _EMBEDDING_MODEL_NAME == DEFAULT_EMBEDDING_MODEL else "configured"
+    )
     _FIRST_FAILURE_TIME = 0.0
     _EMBEDDING_CACHE.clear()
     if hasattr(_get_embedding_model, "_attempt_count"):
@@ -181,7 +194,12 @@ def has_onnx_runtime() -> bool:
 def _get_onnx_model_dir() -> Optional[str]:
     """Get the ONNX model directory path, checking if model exists.
 
-    Checks in order: bge-small-en-v1.5 (primary), env override, all-MiniLM-L6-v2 (fallback).
+    Checks in order: env override, configured model dir, all-MiniLM-L6-v2 (fallback).
+
+    The env override is consulted FIRST. It used to come second, after the
+    default cache path — and since ``omega setup --download-model`` installs
+    exactly that path, the override was unreachable on any normal install.
+    An operator who points OMEGA_ONNX_MODEL_DIR at a different model means it.
     """
     global _ONNX_MODEL_DIR, _EMBEDDING_MODEL_NAME, _EMBEDDING_MODEL_VERSION
     if _ONNX_MODEL_DIR is not None:
@@ -190,20 +208,24 @@ def _get_onnx_model_dir() -> Optional[str]:
     import os
     from pathlib import Path
 
-    # Primary: bge-small-en-v1.5
+    # Environment override — wins over the packaged default.
+    env_dir = os.environ.get("OMEGA_ONNX_MODEL_DIR")
+    if env_dir:
+        env_path = Path(os.path.expanduser(env_dir)) / "model.onnx"
+        if env_path.exists():
+            _ONNX_MODEL_DIR = os.path.expanduser(env_dir)
+            return _ONNX_MODEL_DIR
+        logger.warning(
+            "OMEGA_ONNX_MODEL_DIR=%s has no model.onnx; falling back to the configured model",
+            env_dir,
+        )
+
+    # Configured model (OMEGA_EMBEDDING_MODEL / OMEGA_EMBEDDING_MODEL_DIR).
     model_dir = Path(os.path.expanduser(_ONNX_DEFAULT_DIR))
     model_path = model_dir / "model.onnx"
     if model_path.exists():
         _ONNX_MODEL_DIR = str(model_dir)
         return _ONNX_MODEL_DIR
-
-    # Environment override
-    env_dir = os.environ.get("OMEGA_ONNX_MODEL_DIR")
-    if env_dir:
-        env_path = Path(env_dir) / "model.onnx"
-        if env_path.exists():
-            _ONNX_MODEL_DIR = env_dir
-            return _ONNX_MODEL_DIR
 
     # Fallback: all-MiniLM-L6-v2 (existing installs)
     fallback_dir = Path(os.path.expanduser(_ONNX_FALLBACK_DIR))
@@ -277,7 +299,9 @@ def _get_embedding_model():
                 from tokenizers import Tokenizer as FastTokenizer
 
                 tokenizer = FastTokenizer.from_file(f"{onnx_dir}/tokenizer.json")
-                tokenizer.enable_padding(pad_id=0, pad_token="[PAD]")
+                tokenizer.enable_padding(
+                    pad_id=_EMBEDDING_CONFIG.pad_id, pad_token=_EMBEDDING_CONFIG.pad_token
+                )
                 tokenizer.enable_truncation(max_length=512)
                 sess_opts = ort.SessionOptions()
                 sess_opts.log_severity_level = 4
@@ -382,7 +406,7 @@ def get_active_backend() -> Optional[str]:
     return _EMBEDDING_BACKEND
 
 
-def _hash_embedding(text: str, dimension: int = 384) -> List[float]:
+def _hash_embedding(text: str, dimension: int = _EMBEDDING_CONFIG.dim) -> List[float]:
     """Fallback: deterministic pseudo-embedding from text hash."""
     hash_digest = hashlib.md5(text.encode()).digest()
     seed = int.from_bytes(hash_digest[:4], byteorder="big")
@@ -415,10 +439,17 @@ def _onnx_encode(tokenizer, session, texts: List[str]) -> "np.ndarray":
     outputs = session.run(None, feed)
     embeddings = outputs[1] if len(outputs) > 1 else outputs[0]
     if embeddings.ndim == 3:
-        mask_expanded = mask[:, :, np.newaxis].astype(np.float32)
-        sum_emb = np.sum(embeddings * mask_expanded, axis=1)
-        sum_mask = np.clip(np.sum(mask_expanded, axis=1), a_min=1e-9, a_max=None)
-        embeddings = sum_emb / sum_mask
+        # Pooling is model-specific: bge-small uses mean over the unmasked
+        # tokens, bge-m3 and other CLS-trained models take the first token.
+        # Pooling the wrong way produces vectors that are numerically valid
+        # and semantically wrong, so it is configuration, not a heuristic.
+        if _EMBEDDING_CONFIG.pooling == "cls":
+            embeddings = embeddings[:, 0, :]
+        else:
+            mask_expanded = mask[:, :, np.newaxis].astype(np.float32)
+            sum_emb = np.sum(embeddings * mask_expanded, axis=1)
+            sum_mask = np.clip(np.sum(mask_expanded, axis=1), a_min=1e-9, a_max=None)
+            embeddings = sum_emb / sum_mask
     norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
     return embeddings / np.clip(norms, a_min=1e-9, a_max=None)
 
@@ -431,8 +462,8 @@ def is_embedding_degraded() -> bool:
     return _embedding_degraded
 
 
-def generate_embedding(text: str, dimension: int = 384) -> List[float]:
-    """Generate semantic embedding from text. Returns 384-dim normalized vector.
+def generate_embedding(text: str, dimension: int = _EMBEDDING_CONFIG.dim) -> List[float]:
+    """Generate semantic embedding from text. Returns a normalized vector.
 
     Priority: daemon > in-process ONNX > hash fallback.
     """
@@ -574,7 +605,7 @@ def get_embedding_info() -> Dict[str, Any]:
         "model_loaded": _EMBEDDING_MODEL is not None,
         "onnx_available": has_onnx,
         "onnx_model_dir": _get_onnx_model_dir() if has_onnx else None,
-        "dimension": 384,
+        "dimension": _EMBEDDING_CONFIG.dim,
         "cache_size": len(_EMBEDDING_CACHE),
         "lazy_loading": True,
     }
@@ -595,7 +626,7 @@ def _get_embedding_executor() -> ThreadPoolExecutor:
     return _EMBEDDING_EXECUTOR
 
 
-async def generate_embedding_async(text: str, dimension: int = 384) -> List[float]:
+async def generate_embedding_async(text: str, dimension: int = _EMBEDDING_CONFIG.dim) -> List[float]:
     """Generate embedding asynchronously (non-blocking)."""
     loop = asyncio.get_running_loop()
     return await loop.run_in_executor(_get_embedding_executor(), generate_embedding, text, dimension)

--- a/src/omega/embedding_config.py
+++ b/src/omega/embedding_config.py
@@ -1,0 +1,142 @@
+"""Validated embedding model configuration.
+
+The ``OMEGA_EMBEDDING_*`` variables are read once when the process imports
+this module. Restart the MCP process after changing them.
+
+These exist so that non-default embedding models -- notably multilingual ones
+such as ``bge-m3`` (1024-dim, CLS pooling) -- can be selected through
+configuration instead of source patches that every upgrade silently reverts.
+
+The dimension recorded here must match the ``vec0`` tables in an existing
+store. ``omega.sqlite_store`` validates that on startup and refuses to run on
+a mismatch rather than degrading to a silent no-op.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Optional
+
+__all__ = [
+    "DEFAULT_EMBEDDING_MODEL",
+    "DEFAULT_EMBEDDING_DIM",
+    "DEFAULT_EMBEDDING_POOLING",
+    "VALID_POOLING",
+    "EmbeddingConfig",
+    "load_embedding_config",
+    "get_embedding_config",
+]
+
+DEFAULT_EMBEDDING_MODEL = "bge-small-en-v1.5"
+DEFAULT_EMBEDDING_DIM = 384
+DEFAULT_EMBEDDING_POOLING = "mean"
+DEFAULT_PAD_TOKEN = "[PAD]"
+DEFAULT_PAD_ID = 0
+
+VALID_POOLING = ("mean", "cls")
+
+# Upper bound is a sanity guard, not a model limit: it catches a mistyped
+# dimension before it reaches the vec0 table, where the cost of being wrong is
+# a full re-embed of the store.
+_MAX_EMBEDDING_DIM = 16384
+
+
+@dataclass(frozen=True)
+class EmbeddingConfig:
+    """Resolved embedding configuration for this process."""
+
+    model_name: str
+    dim: int
+    pooling: str
+    model_dir: str
+    pad_token: str
+    pad_id: int
+
+
+def _require_str(source: Mapping[str, str], key: str, default: str) -> str:
+    """Return the trimmed value, treating unset and blank alike as 'use default'.
+
+    Blank is deliberately not an error: ``export OMEGA_EMBEDDING_MODEL=`` is a
+    common way to clear a variable, and it means the same thing as never
+    setting it. This matches ``dedup_config.load_dedup_thresholds``.
+    """
+    raw = source.get(key)
+    if raw is None or not raw.strip():
+        return default
+    return raw.strip()
+
+
+def _require_int(source: Mapping[str, str], key: str, default: int) -> int:
+    raw = source.get(key)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw.strip())
+    except ValueError as exc:
+        raise ValueError(f"{key} must be an integer, got {raw!r}") from exc
+
+
+def load_embedding_config(env: Optional[Mapping[str, str]] = None) -> EmbeddingConfig:
+    """Return the embedding configuration, validated.
+
+    Args:
+        env: Environment mapping to read from. Defaults to ``os.environ``.
+
+    Returns:
+        The resolved :class:`EmbeddingConfig`.
+
+    Raises:
+        ValueError: If any variable is malformed or out of range. Failing here
+            is deliberate -- a bad dimension that reaches the store writes
+            memories with no retrievable vector.
+    """
+    source = os.environ if env is None else env
+
+    model_name = _require_str(source, "OMEGA_EMBEDDING_MODEL", DEFAULT_EMBEDDING_MODEL)
+
+    dim = _require_int(source, "OMEGA_EMBEDDING_DIM", DEFAULT_EMBEDDING_DIM)
+    if not 1 <= dim <= _MAX_EMBEDDING_DIM:
+        raise ValueError(
+            f"OMEGA_EMBEDDING_DIM must be between 1 and {_MAX_EMBEDDING_DIM}, got {dim}"
+        )
+
+    pooling = _require_str(
+        source, "OMEGA_EMBEDDING_POOLING", DEFAULT_EMBEDDING_POOLING
+    ).lower()
+    if pooling not in VALID_POOLING:
+        raise ValueError(
+            f"OMEGA_EMBEDDING_POOLING must be one of {', '.join(VALID_POOLING)}, got {pooling!r}"
+        )
+
+    model_dir = _require_str(
+        source,
+        "OMEGA_EMBEDDING_MODEL_DIR",
+        f"~/.cache/omega/models/{model_name}-onnx",
+    )
+
+    pad_token = _require_str(source, "OMEGA_EMBEDDING_PAD_TOKEN", DEFAULT_PAD_TOKEN)
+
+    pad_id = _require_int(source, "OMEGA_EMBEDDING_PAD_ID", DEFAULT_PAD_ID)
+    if pad_id < 0:
+        raise ValueError(f"OMEGA_EMBEDDING_PAD_ID must be non-negative, got {pad_id}")
+
+    return EmbeddingConfig(
+        model_name=model_name,
+        dim=dim,
+        pooling=pooling,
+        model_dir=model_dir,
+        pad_token=pad_token,
+        pad_id=pad_id,
+    )
+
+
+# Resolved once at import. Mirrors the dedup-threshold configuration contract:
+# a malformed value fails the process at startup rather than at the first write.
+_CONFIG = load_embedding_config()
+
+
+def get_embedding_config() -> EmbeddingConfig:
+    """Return the process-wide embedding configuration resolved at import."""
+    return _CONFIG

--- a/src/omega/sqlite_store/_base.py
+++ b/src/omega/sqlite_store/_base.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 import sqlite3
 import threading
 import time as _time
@@ -12,6 +13,7 @@ from typing import Any, Dict, List, Optional
 
 from omega import json_compat as json
 from omega.db_utils import retry_on_locked as _retry_on_locked
+from omega.exceptions import StorageError
 from omega.schema import SCHEMA_VERSION  # noqa: F401 -- re-exported
 from omega.schema import init_schema as _init_schema_fn
 
@@ -526,6 +528,35 @@ class SQLiteStoreBase:
         self._vec_available, self._fts_available = _init_schema_fn(
             self._conn, self._vec_available, EMBEDDING_DIM
         )
+        if self._vec_available:
+            self._verify_embedding_dim()
+
+    def _verify_embedding_dim(self) -> None:
+        """Fail loudly if the configured dimension disagrees with the store.
+
+        ``CREATE VIRTUAL TABLE IF NOT EXISTS`` silently keeps the dimension an
+        existing table was built with, so an upgrade that changes
+        ``OMEGA_EMBEDDING_DIM`` (or reverts a patched default) leaves every
+        subsequent write failing its dimension check at run time. Catching it
+        at open turns a slow trickle of rejected writes into one clear error.
+        """
+        row = self._conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'memories_vec'"
+        ).fetchone()
+        if not row or not row[0]:
+            return
+        match = re.search(r"float\[(\d+)\]", row[0])
+        if not match:
+            return
+        actual = int(match.group(1))
+        if actual != EMBEDDING_DIM:
+            raise StorageError(
+                f"Embedding dimension mismatch: memories_vec was created with "
+                f"{actual} dimensions but this process is configured for "
+                f"{EMBEDDING_DIM} (OMEGA_EMBEDDING_DIM). Set OMEGA_EMBEDDING_DIM="
+                f"{actual} to match the existing store, or re-embed the store "
+                f"at {EMBEDDING_DIM} dimensions."
+            )
 
     def get_thread_local_read_conn(self) -> sqlite3.Connection:
         """Return a lazily created per-thread connection for analyzer reads.

--- a/src/omega/sqlite_store/_store.py
+++ b/src/omega/sqlite_store/_store.py
@@ -10,9 +10,26 @@ from typing import Any, Dict, List, Optional
 
 from omega import json_compat as json
 from omega.exceptions import StorageError
-from ._types import MemoryResult, _serialize_f32, _canonicalize
+from ._types import EMBEDDING_DIM, MemoryResult, _serialize_f32, _canonicalize
 
 logger = logging.getLogger("omega.sqlite_store")
+
+
+def _check_embedding_dim(embedding: List[float]) -> None:
+    """Raise if ``embedding`` does not match the configured vector dimension.
+
+    Checked before the insert so the failure names both dimensions. sqlite-vec
+    reports its own mismatch, but the store is the only layer that knows the
+    configured dimension came from ``OMEGA_EMBEDDING_DIM``, which is what the
+    operator actually has to change.
+    """
+    if len(embedding) != EMBEDDING_DIM:
+        raise StorageError(
+            f"Embedding dimension mismatch: got {len(embedding)}, "
+            f"store expects {EMBEDDING_DIM}. The vector tables were built at "
+            f"{EMBEDDING_DIM} dimensions; set OMEGA_EMBEDDING_DIM to match the "
+            f"embedding model and re-embed the store if the model changed."
+        )
 
 
 class StoreMixin:
@@ -257,12 +274,25 @@ class StoreMixin:
 
             # Insert embedding into vec table
             if embedding and self._vec_available:
+                # A failure here used to be logged at DEBUG and swallowed, so
+                # the memory row committed with no vector and store() still
+                # returned an id: the write reported success and was
+                # unretrievable by every later semantic search. Roll the whole
+                # store back and raise instead — a rejected write the caller
+                # can retry beats a silently vectorless one.
                 try:
+                    _check_embedding_dim(embedding)
                     self._exec(
                         "INSERT INTO memories_vec (rowid, embedding) VALUES (?, ?)", (rowid, _serialize_f32(embedding))
                     )
+                except StorageError:
+                    # Dimension mismatch: the message already says what to fix.
+                    self._conn.rollback()
+                    raise
                 except Exception as e:
-                    logger.debug(f"Vec insert failed: {e}")
+                    self._conn.rollback()
+                    logger.error("Vec insert failed; rolled back store: %s", e, exc_info=True)
+                    raise StorageError(f"Failed to store embedding vector: {e}") from e
 
             # Add causal edges if dependencies provided
             if dependencies:
@@ -456,14 +486,26 @@ class StoreMixin:
             if new_embedding is not None:
                 row = self._exec("SELECT id FROM memories WHERE node_id = ?", (node_id,)).fetchone()
                 if row:
+                    # The DELETE lands before the INSERT, so swallowing a
+                    # failure here discarded the memory's existing, working
+                    # vector and left it with none — silent data loss on a
+                    # record that was previously fine. Roll back instead.
                     try:
+                        _check_embedding_dim(new_embedding)
                         self._exec("DELETE FROM memories_vec WHERE rowid = ?", (row[0],))
                         self._exec(
                             "INSERT INTO memories_vec (rowid, embedding) VALUES (?, ?)",
                             (row[0], _serialize_f32(new_embedding)),
                         )
+                    except StorageError:
+                        self._conn.rollback()
+                        raise
                     except Exception as e:
-                        logger.debug("update_node: vec update failed: %s", e)
+                        self._conn.rollback()
+                        logger.error(
+                            "update_node: vec update failed; rolled back: %s", e, exc_info=True
+                        )
+                        raise StorageError(f"Failed to update embedding vector: {e}") from e
             self._commit()
         return True
 

--- a/src/omega/sqlite_store/_types.py
+++ b/src/omega/sqlite_store/_types.py
@@ -7,9 +7,12 @@ from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
+from omega.embedding_config import get_embedding_config
 from omega.schema import SCHEMA_VERSION  # noqa: F401 -- re-exported
 
-EMBEDDING_DIM = 384
+# Resolved from OMEGA_EMBEDDING_DIM at import. Must match the dimension the
+# vec0 tables were created with; SQLiteStore validates that on open.
+EMBEDDING_DIM = get_embedding_config().dim
 
 # Pre-compiled regex for query deduplication (strip trailing git hashes)
 _TRAILING_HASH_RE = re.compile(r"\s*-\s*[0-9a-f]{6,40}\s*$")

--- a/tests/test_embedding_config.py
+++ b/tests/test_embedding_config.py
@@ -1,0 +1,83 @@
+"""Tests for OMEGA_EMBEDDING_* configuration.
+
+Multilingual deployments run non-default models (bge-m3: 1024-dim, CLS
+pooling). Before this module the model name, directory, pooling, pad token and
+dimension were literals in five files, so every upgrade reverted them and the
+resulting dimension mismatch lost vectors silently.
+
+These tests pin the contract: values come from the environment, and malformed
+values raise at load time rather than reaching the store.
+"""
+
+import pytest
+
+from omega.embedding_config import (
+    DEFAULT_EMBEDDING_DIM,
+    DEFAULT_EMBEDDING_MODEL,
+    load_embedding_config,
+)
+
+
+def test_defaults_match_shipped_model():
+    """No configuration means the factory bge-small-en-v1.5 setup."""
+    config = load_embedding_config(env={})
+    assert config.model_name == DEFAULT_EMBEDDING_MODEL
+    assert config.dim == DEFAULT_EMBEDDING_DIM
+    assert config.pooling == "mean"
+    assert config.model_dir.endswith("bge-small-en-v1.5-onnx")
+
+
+def test_bge_m3_configuration_round_trips():
+    """The multilingual case this feature exists for."""
+    config = load_embedding_config(
+        env={
+            "OMEGA_EMBEDDING_MODEL": "bge-m3",
+            "OMEGA_EMBEDDING_DIM": "1024",
+            "OMEGA_EMBEDDING_POOLING": "cls",
+        }
+    )
+    assert config.model_name == "bge-m3"
+    assert config.dim == 1024
+    assert config.pooling == "cls"
+    # Model dir follows the model name unless overridden.
+    assert config.model_dir.endswith("bge-m3-onnx")
+
+
+def test_explicit_model_dir_overrides_derived_path():
+    config = load_embedding_config(
+        env={"OMEGA_EMBEDDING_MODEL": "bge-m3", "OMEGA_EMBEDDING_MODEL_DIR": "/models/custom"}
+    )
+    assert config.model_dir == "/models/custom"
+
+
+def test_pad_token_and_id_are_configurable():
+    config = load_embedding_config(
+        env={"OMEGA_EMBEDDING_PAD_TOKEN": "<pad>", "OMEGA_EMBEDDING_PAD_ID": "1"}
+    )
+    assert config.pad_token == "<pad>"
+    assert config.pad_id == 1
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        {"OMEGA_EMBEDDING_DIM": "not-a-number"},
+        {"OMEGA_EMBEDDING_DIM": "0"},
+        {"OMEGA_EMBEDDING_DIM": "-1"},
+        {"OMEGA_EMBEDDING_DIM": "999999"},
+        {"OMEGA_EMBEDDING_POOLING": "max"},
+        {"OMEGA_EMBEDDING_PAD_ID": "-1"},
+        {"OMEGA_EMBEDDING_PAD_ID": "not-a-number"},
+    ],
+)
+def test_malformed_values_raise(env):
+    """Fail at load, not at the first write."""
+    with pytest.raises(ValueError):
+        load_embedding_config(env=env)
+
+
+def test_unset_and_blank_values_fall_back_to_defaults():
+    """A blank var is 'unset', not an error — matches shell export habits."""
+    config = load_embedding_config(env={"OMEGA_EMBEDDING_DIM": "  ", "OMEGA_EMBEDDING_POOLING": ""})
+    assert config.dim == DEFAULT_EMBEDDING_DIM
+    assert config.pooling == "mean"

--- a/tests/test_embedding_dim_startup_check.py
+++ b/tests/test_embedding_dim_startup_check.py
@@ -1,0 +1,157 @@
+"""Startup validation of the configured dimension against the existing store.
+
+``CREATE VIRTUAL TABLE IF NOT EXISTS`` keeps whatever dimension the table was
+first built with. So an upgrade that reverts a patched default (or a changed
+OMEGA_EMBEDDING_DIM) leaves the process configured for one dimension and the
+store built for another, and every later write fails its dimension check one at
+a time. The customer who reported this lost seven hours to that trickle.
+
+Opening the store must surface the mismatch immediately.
+
+These run in SUBPROCESSES on purpose. ``OMEGA_EMBEDDING_DIM`` is read once at
+import and copied into module-level names, so exercising a second dimension
+means importing the package again. Doing that in-process by editing
+``sys.modules`` corrupts the rest of the suite: other modules captured the
+original module objects and patch attributes on them, so their patches start
+landing on a module the code under test no longer uses. A subprocess gets a
+genuinely fresh interpreter and cannot leak into anyone else.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).resolve().parent.parent / "src"
+
+
+def _run(code: str, dim: str) -> subprocess.CompletedProcess:
+    """Execute ``code`` in a fresh interpreter configured for ``dim``."""
+    import os
+
+    env = dict(os.environ)
+    env["OMEGA_EMBEDDING_DIM"] = dim
+    env["PYTHONPATH"] = str(_SRC) + os.pathsep + env.get("PYTHONPATH", "")
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+    )
+
+
+def _skip_if_no_vec(result: subprocess.CompletedProcess) -> None:
+    if "NO_VEC" in result.stdout:
+        pytest.skip("sqlite-vec unavailable; dimension enforcement is vec-specific")
+
+
+_MAKE_STORE = """
+import sys
+from omega.sqlite_store import SQLiteStore
+store = SQLiteStore(sys.argv[1] if len(sys.argv) > 1 else {db!r})
+if not store._vec_available:
+    print("NO_VEC")
+    raise SystemExit(0)
+{body}
+"""
+
+
+def test_store_is_created_at_the_configured_dimension(tmp_path):
+    db = str(tmp_path / "omega1024.db")
+    result = _run(
+        _MAKE_STORE.format(
+            db=db,
+            body="""
+sql = store._conn.execute(
+    "SELECT sql FROM sqlite_master WHERE name = 'memories_vec'").fetchone()[0]
+assert "float[1024]" in sql, sql
+store.store("multilingual memory", embedding=[0.1] * 1024)
+n = store._conn.execute("SELECT COUNT(*) FROM memories_vec").fetchone()[0]
+assert n == 1, n
+print("OK")
+""",
+        ),
+        dim="1024",
+    )
+    _skip_if_no_vec(result)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_opening_a_store_at_the_wrong_dimension_raises(tmp_path):
+    db = str(tmp_path / "omega.db")
+
+    built = _run(
+        _MAKE_STORE.format(
+            db=db,
+            body="""
+store.store("built at 384", embedding=[0.1] * 384)
+store.close()
+print("OK")
+""",
+        ),
+        dim="384",
+    )
+    _skip_if_no_vec(built)
+    assert built.returncode == 0, built.stderr
+
+    # Simulate the upgrade: same database, process now configured for 1024.
+    reopened = _run(
+        f"""
+from omega.sqlite_store import SQLiteStore
+try:
+    SQLiteStore({db!r})
+except Exception as exc:
+    print("RAISED:" + str(exc))
+else:
+    print("NO_ERROR")
+""",
+        dim="1024",
+    )
+    assert "RAISED:" in reopened.stdout, reopened.stdout + reopened.stderr
+    message = reopened.stdout
+    assert "384" in message and "1024" in message
+    assert "OMEGA_EMBEDDING_DIM" in message
+
+
+def test_matching_dimension_opens_cleanly(tmp_path):
+    db = str(tmp_path / "omega.db")
+    first = _run(_MAKE_STORE.format(db=db, body='store.close()\nprint("OK")'), dim="384")
+    _skip_if_no_vec(first)
+    assert first.returncode == 0, first.stderr
+
+    again = _run(
+        f"""
+from omega.sqlite_store import SQLiteStore
+store = SQLiteStore({db!r})
+store.close()
+print("OK")
+""",
+        dim="384",
+    )
+    assert again.returncode == 0, again.stderr
+    assert "OK" in again.stdout
+
+
+def test_legacy_store_without_vec_table_is_not_blocked(tmp_path):
+    """A database with no vec table predates vectors — opening must not fail."""
+    db = str(tmp_path / "legacy.db")
+    result = _run(
+        f"""
+import sqlite3
+conn = sqlite3.connect({db!r})
+conn.execute("CREATE TABLE placeholder (id INTEGER PRIMARY KEY)")
+conn.commit()
+conn.close()
+
+from omega.sqlite_store import SQLiteStore
+store = SQLiteStore({db!r})
+store.close()
+print("OK")
+""",
+        dim="1024",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout

--- a/tests/test_vec_dimension_mismatch.py
+++ b/tests/test_vec_dimension_mismatch.py
@@ -1,0 +1,94 @@
+"""Regression tests for silent vector loss on embedding-dimension mismatch.
+
+Reported 2026-08-16 by a customer running a 1024-dim model against vec tables
+built at 384. The memories row was inserted and its id returned, then the
+``memories_vec`` insert raised, and the handler swallowed it:
+
+    except Exception as e:
+        logger.debug(f"Vec insert failed: {e}")
+
+``logger.debug`` is below the default INFO level, so nothing surfaced. Writes
+reported success while storing no vector for seven hours. Document ingestion
+performs the same insert without a guard, so it failed loudly -- which is the
+only reason the problem was noticed at all.
+
+These tests pin two properties:
+  1. A dimension mismatch raises instead of reporting a successful store.
+  2. The failed store leaves no row behind -- the memory and its vector are
+     written atomically, so a rejected write cannot leave an unretrievable
+     memory that every later search misses.
+"""
+
+import pytest
+
+from omega.exceptions import StorageError
+from omega.sqlite_store import EMBEDDING_DIM, SQLiteStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    store = SQLiteStore(str(tmp_path / "omega.db"))
+    if not store._vec_available:
+        pytest.skip("sqlite-vec unavailable; dimension enforcement is vec-specific")
+    return store
+
+
+def _count_memories(store) -> int:
+    return store._conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0]
+
+
+def _count_vectors(store) -> int:
+    return store._conn.execute("SELECT COUNT(*) FROM memories_vec").fetchone()[0]
+
+
+def test_mismatched_dimension_raises_instead_of_silently_dropping(store):
+    """The seven-hour outage: store() returned an id and stored no vector."""
+    wrong = [0.1] * (EMBEDDING_DIM * 2)
+
+    with pytest.raises(StorageError) as excinfo:
+        store.store("memory written with a mismatched embedding", embedding=wrong)
+
+    message = str(excinfo.value)
+    # The error has to name both numbers, or the operator cannot tell which
+    # side is wrong without reading the source.
+    assert str(len(wrong)) in message
+    assert str(EMBEDDING_DIM) in message
+
+
+def test_rejected_store_leaves_no_orphaned_memory(store):
+    """Atomicity: a rejected write must not leave a vectorless memory row.
+
+    Without an explicit rollback the pending INSERT stays in the writer
+    connection's open IMMEDIATE transaction and is committed by the next
+    successful write -- trading silent vector loss for silent corruption.
+    """
+    before = _count_memories(store)
+
+    with pytest.raises(StorageError):
+        store.store("rejected write", embedding=[0.1] * (EMBEDDING_DIM * 2))
+
+    assert _count_memories(store) == before
+
+    # A subsequent good write must not resurrect the rejected row.
+    store.store("good write", embedding=[0.1] * EMBEDDING_DIM)
+
+    assert _count_memories(store) == before + 1
+    assert _count_vectors(store) == 1
+    rows = store._conn.execute("SELECT content FROM memories").fetchall()
+    assert [r[0] for r in rows] == ["good write"]
+
+
+def test_correct_dimension_still_stores_vector(store):
+    """The happy path stays intact."""
+    node_id = store.store("well-formed memory", embedding=[0.1] * EMBEDDING_DIM)
+
+    assert node_id
+    assert _count_vectors(store) == 1
+
+
+def test_store_without_embedding_is_unaffected(store):
+    """Callers that pass no embedding must not start failing."""
+    node_id = store.store("no embedding supplied")
+
+    assert node_id
+    assert _count_memories(store) == 1


### PR DESCRIPTION
## The bug

A failed `memories_vec` insert was logged at `DEBUG` and swallowed. `store()`
returned an id and reported success while the memory row committed **with no
vector** — invisible to every later semantic search.

The usual trigger is an embedding-dimension mismatch, which an upgrade can
introduce silently: `CREATE VIRTUAL TABLE IF NOT EXISTS` keeps the dimension
the table was originally built with, so switching models leaves every write
failing its dimension check at run time with no visible signal. It was reported
by a user running a 1024-dim multilingual model whose store had been built at
1024 and whose configuration reverted to 384 on upgrade.

`update_node()` had the same bug in a worse form: it `DELETE`s the existing
vector before `INSERT`ing the new one, so a swallowed failure discarded a
working vector and left the record with none.

## What changed

- Both write paths roll back and raise instead of swallowing. A rejected write
  leaves no vectorless row behind.
- Opening a store compares the configured dimension against the dimension in
  the `memories_vec` DDL and refuses to open on a mismatch — one clear error at
  startup instead of a slow trickle of rejected writes.
- Model, dimension, pooling, model directory and pad token move to
  `OMEGA_EMBEDDING_*` in a new `omega.embedding_config`, read once at import
  and validated. These were literals across five modules, so multilingual
  deployments carried local patches that every upgrade reverted.
- `pooling=cls` for CLS-trained models such as `bge-m3`; `mean` stays default.
- `OMEGA_ONNX_MODEL_DIR` is now consulted **before** the packaged default. It
  was previously reached only when the default path was missing, and since
  `omega setup --download-model` installs exactly that path, the override was
  unreachable on a normal install.

## Verification

The regression was reproduced on unmodified `main` (v1.5.10) with only the new
test file added:

```
FAILED test_mismatched_dimension_raises_instead_of_silently_dropping
FAILED test_rejected_store_leaves_no_orphaned_memory
E   Failed: DID NOT RAISE <class 'omega.exceptions.StorageError'>
```

With this branch: **1635 passed, 6 skipped**, `ruff check src/` clean.
Baseline before the change was 1615 passed — the 20 new tests account for the
difference.

`test_embedding_dim_startup_check` runs in subprocesses: `OMEGA_EMBEDDING_DIM`
is read at import, and exercising that in-process needs `sys.modules` surgery
that rebinds modules other tests hold references to.

## Compatibility

Default behaviour is unchanged — `bge-small-en-v1.5`, 384 dimensions, mean
pooling. Existing stores open exactly as before.

Writes that previously failed silently now raise `StorageError`. That is the
point of the change, but it is a behavioural change for any deployment that was
unknowingly relying on the silent path.